### PR TITLE
hcreate_r error fixed

### DIFF
--- a/host/cheetah_aggregate_processing.c
+++ b/host/cheetah_aggregate_processing.c
@@ -75,7 +75,7 @@ cheetah_aggregate_processing_distinct_init(const uint32_t size) {
 
   struct cheetah_aggregate_processing_distinct_state *state;
 
-  state = malloc(sizeof(struct cheetah_aggregate_processing_distinct_state));
+  state = calloc(1, sizeof(struct cheetah_aggregate_processing_distinct_state));
 
   state->size = size;
   state->current_entries = 0;
@@ -197,7 +197,7 @@ cheetah_aggregate_processing_groupby_init(const uint32_t size) {
 
   struct cheetah_aggregate_processing_groupby_state *state;
 
-  state = malloc(sizeof(struct cheetah_aggregate_processing_groupby_state));
+  state = calloc(1, sizeof(struct cheetah_aggregate_processing_groupby_state));
 
   state->size = size;
   state->current_entries = 0;

--- a/host/cheetah_join.c
+++ b/host/cheetah_join.c
@@ -10,7 +10,7 @@ struct cheetah_join_state *cheetah_join_init(const uint64_t size,
   int rtn;
   struct cheetah_join_state *state;
 
-  state = malloc(sizeof(struct cheetah_join_state));
+  state = calloc(1, sizeof(struct cheetah_join_state));
   assert(state != NULL);
 
   state->entries = malloc(sizeof(struct cheetah_join_entry) * size);


### PR DESCRIPTION
To use calloc() to allocate the memory instead of malloc().

The malloc() may lead to random non-zero values. the content of `state->htab` needs to be zero before calling hcreate_r(), otherwise it fails.

```
cheetah_join.c:23: cheetah_join_init: Assertion `rtn != 0' failed.
```

Thanks,
Lam